### PR TITLE
Serve images in next gen formats

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -5,7 +5,8 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.addPlugin(localImages, {
     distPath: "_site",
     assetPath: "/assets/img",
-    selector: "img",
+    selector: "source",
+    attribute: "srcset",
     verbose: false,
   });
 

--- a/src/index.md
+++ b/src/index.md
@@ -1,10 +1,16 @@
 ---
 layout: default.njk
+templateEngineOverride: njk,md
+headshotLink: https://res.cloudinary.com/dave-powers/image/upload/c_scale,w_440/v1586371313/dave_powers_headshot
 ---
 
 # Who am I?!
 
-![Dave Powers wearing a t-shirt](https://avatars1.githubusercontent.com/u/4978418)
+<picture>
+  <source type="image/webp" srcset="{{ headshotLink }}.webp">
+  <source type="image/jpeg" srcset="{{ headshotLink }}.jpg">
+  <img src="{{ headshotLink }}.jpg" alt="Dave Powers wearing a t-shirt">
+</picture>
 
 I'm [@dave_powers](https://twitter.com/dave_powers), a web developer, humor writer, and interrobang advocate. Check out what I'm up to [now](now/).
 

--- a/src/index.md
+++ b/src/index.md
@@ -9,7 +9,7 @@ headshotLink: https://res.cloudinary.com/dave-powers/image/upload/c_scale,w_440/
 <picture>
   <source type="image/webp" srcset="{{ headshotLink }}.webp">
   <source type="image/jpeg" srcset="{{ headshotLink }}.jpg">
-  <img src="{{ headshotLink }}.jpg" alt="Dave Powers wearing a t-shirt">
+  <img src="data:," alt="Dave Powers wearing a t-shirt">
 </picture>
 
 I'm [@dave_powers](https://twitter.com/dave_powers), a web developer, humor writer, and interrobang advocate. Check out what I'm up to [now](now/).


### PR DESCRIPTION
Addressing suggestion via Google Lighthouse

With the local images plugin used, it doesn't appear able to target multiple image attribute types (e.g., can't target `srcset` and `src` for both `source` and `img` elements, respectively).

Ignoring this pulls in the external image link, but I want to avoid serving that in production, even as a fallback.

Considered populating the value via client-side JavaScript, but this seems hacky for a scenario that will likely occur rarely, if ever.

- https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture
- https://caniuse.com/#feat=picture

- https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source
- https://caniuse.com/#feat=webp
