### PR TITLE
Add section for posts

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,5 +1,6 @@
 const localImages = require("eleventy-plugin-local-images");
 const CleanCSS = require("clean-css");
+const readingTime = require("eleventy-plugin-reading-time");
 
 module.exports = function (eleventyConfig) {
   eleventyConfig.addPlugin(localImages, {
@@ -13,6 +14,8 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.addFilter("cssmin", function (code) {
     return new CleanCSS({}).minify(code).styles;
   });
+
+  eleventyConfig.addPlugin(readingTime);
 
   eleventyConfig.addPassthroughCopy("robots.txt");
   eleventyConfig.addPassthroughCopy("_redirects");

--- a/package-lock.json
+++ b/package-lock.json
@@ -2130,6 +2130,11 @@
         }
       }
     },
+    "eleventy-plugin-reading-time": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/eleventy-plugin-reading-time/-/eleventy-plugin-reading-time-0.0.1.tgz",
+      "integrity": "sha512-6MRHwrWMYm/u9lJK4/mnyS+6SyQxJSQcTfa1DqQS9fpQRPsZ9mdO9rZ/6DAhZpX2/cXxrbc6qxgcv6Qj90im1g=="
+    },
     "emitter-mixin": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/emitter-mixin/-/emitter-mixin-0.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -17,5 +17,8 @@
     "clean-css": "^4.2.3",
     "eleventy-plugin-local-images": "^0.4.0",
     "prettier": "^2.0.5"
+  },
+  "dependencies": {
+    "eleventy-plugin-reading-time": "0.0.1"
   }
 }

--- a/src/_includes/main.css
+++ b/src/_includes/main.css
@@ -46,6 +46,10 @@ main a {
   color: midnightblue;
 }
 
+main ul li {
+  margin: 16px 0;
+}
+
 img {
   width: 100%;
 }

--- a/src/_includes/post.njk
+++ b/src/_includes/post.njk
@@ -1,0 +1,12 @@
+---
+layout: default.njk
+---
+
+<h1>{{ title }}</h1>
+<time itemprop="datePublished" datetime="{{ date }}">
+  {{ page.date.toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric"}) }}
+</time>
+
+<article>
+  {{ content | safe }}
+</article>

--- a/src/_includes/post.njk
+++ b/src/_includes/post.njk
@@ -6,6 +6,8 @@ layout: default.njk
 <time itemprop="datePublished" datetime="{{ date }}">
   {{ page.date.toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric"}) }}
 </time>
+&middot;
+<span>{{ content | readingTime }} reading time</span>
 
 <article>
   {{ content | safe }}

--- a/src/posts/posts.json
+++ b/src/posts/posts.json
@@ -1,0 +1,1 @@
+{ "layout": "post.njk" }

--- a/src/posts/posts.njk
+++ b/src/posts/posts.njk
@@ -1,0 +1,15 @@
+---
+layout: default.njk
+---
+
+<h1>Posts</h1>
+<ul>
+{%- for post in collections.post | reverse -%}
+  <li>
+    <a href="{{ post.url }}">{{ post.data.title }}</a>
+    <time datetime="{{ post.date }}">
+      {{ post.date.toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric"}) }}
+    </time>
+  </li>
+{%- endfor -%}
+</ul>

--- a/src/writing.njk
+++ b/src/writing.njk
@@ -7,9 +7,9 @@ description: Links to external sites where Dave Powers has been published
 <h1>Writing</h1>
 {% for publication in publications %}
   <h2>{{ publication.name }}</h2>
-  {% for piece in publication.pieces %}
-    <ul>
+  <ul>
+    {% for piece in publication.pieces %}
       <li><a href="{{ piece.url }}">{{ piece.title }}</a>
-    </ul>
-  {% endfor %}
+    {% endfor %}
+  </ul>
 {% endfor %}

--- a/src/writing.njk
+++ b/src/writing.njk
@@ -5,6 +5,11 @@ description: Links to external sites where Dave Powers has been published
 ---
 
 <h1>Writing</h1>
+
+<em>
+  Posts published on this site can be found <a href="/posts/">here</a>.
+</em>
+
 {% for publication in publications %}
   <h2>{{ publication.name }}</h2>
   <ul>


### PR DESCRIPTION
Adds a "/posts/" page to hold posts (i.e., pieces of writing that are published directly on the site.

Uses a new [Eleventy Layout](https://www.11ty.dev/docs/layouts/) as a view partial to wrap around each post item. The posts page renders a [collection](https://www.11ty.dev/docs/collections/) of post items, designated by a tag set in a [directory data file](https://www.11ty.dev/docs/data-template-dir/#example-apply-a-default-layout-to-multiple-templates).